### PR TITLE
Fix linebreaks for numbering in GeoExt

### DIFF
--- a/doc/quickstart/geoext_quickstart.rst
+++ b/doc/quickstart/geoext_quickstart.rst
@@ -22,18 +22,15 @@ Create an HTML page
 
 In this step we will set-up an empty HTML page which will contain the application. We'll use the text editor Leafpad installed on OSGeoLive to create a new HTML file at ``/var/www/html/geoext/demo.html`` 
 
-#. Open Leafpad from the command line with elevated permissions (so you can save the file) using the
-command below:
+#. Open Leafpad from the command line with elevated permissions (so you can save the file) using the command below:
 
    .. code-block:: bash
 
     sudo leafpad
 
-#. Next paste in the HTML below. This contains links to the ExtJS and OpenLayers JavaScript libraries, 
-and two CSS files used to style ExtJS and OpenLayers components. 
+#. Next paste in the HTML below. This contains links to the ExtJS and OpenLayers JavaScript libraries, and two CSS files used to style ExtJS and OpenLayers components. 
 
-   We will use the ``Ext.Loader`` class to load in GeoExt JavaScript source files. These are all in the ``src`` folder 
-in ``/var/www/html/geoext/``. 
+   We will use the ``Ext.Loader`` class to load in GeoExt JavaScript source files. These are all in the ``src`` folder in ``/var/www/html/geoext/``. 
 
    .. code-block:: html
 
@@ -130,7 +127,8 @@ Next we will configure some OpenLayers objects used by the application.
         name: 'Airports'
     });
 
-#. Now we are going to create our OpenLayers map object configured with the layers we just created. We will also set the center and zoom level of the map, and add in a select interaction so we can select features in our vector layer. 
+#. Now we are going to create our OpenLayers map object configured with the layers we just created. We will also set the center 
+   and zoom level of the map, and add in a select interaction so we can select features in our vector layer. 
 
    .. code-block:: js
 
@@ -162,7 +160,10 @@ Now the map and layers have been configured we are going to create and configure
     });
 
 
-#. Next we will create a layer tree component. The tree has its own data store - ``GeoExt.data.store.LayersTree``, which we will fill with layers from our OpenLayers map. The store will then be used to populate our tree panel. We will also add in a plugin to the tree to allow the map layer order to be changed by dragging and dropping the layers. The ``flex`` property causes the tree panel to fill up all available space in its region of the screen. 
+#. Next we will create a layer tree component. The tree has its own data store - ``GeoExt.data.store.LayersTree``, which we will fill 
+   with layers from our OpenLayers map. The store will then be used to populate our tree panel. We will also add in a plugin to the 
+   tree to allow the map layer order to be changed by dragging and dropping the layers. The ``flex`` property causes the tree panel 
+   to fill up all available space in its region of the screen. 
 
    .. code-block:: js
 
@@ -181,7 +182,8 @@ Now the map and layers have been configured we are going to create and configure
         }
     });
 
-#. We are also going to create a grid component to display the attributes of features in our WFS layer. Similar to the layer tree store and tree panel, we create a ``GeoExt.data.store.Features`` store and a grid panel. 
+#. We are also going to create a grid component to display the attributes of features in our WFS layer. 
+   Similar to the layer tree store and tree panel, we create a ``GeoExt.data.store.Features`` store and a grid panel. 
 
    .. code-block:: js
 
@@ -210,7 +212,8 @@ Now the map and layers have been configured we are going to create and configure
         height: 300
     });
 
-#. Our final GeoExt component is an overview map - ``GeoExt.component.OverviewMap``. We will configure this to display the OpenStreetMap layer we created earlier, and place it in an ExtJS panel. 
+#. Our final GeoExt component is an overview map - ``GeoExt.component.OverviewMap``. 
+   We will configure this to display the OpenStreetMap layer we created earlier, and place it in an ExtJS panel. 
 
    .. code-block:: js
 


### PR DESCRIPTION
Note the text also has to be aligned with the # - additional linebreaks and spaces have been added to fix this. 

The linebreaks won't be visible in the rendered HTML output. 