### PR TITLE
Updates following docs review

### DIFF
--- a/doc/quickstart/mapserver_quickstart.rst
+++ b/doc/quickstart/mapserver_quickstart.rst
@@ -6,7 +6,7 @@
 :Reviewer: Cameron Shorter, Jirotech
 :Reviewer: Angelos Tzotsos, OSGeo
 :Reviewer: Felicity Brand (Google Season of Docs 2019)
-:Version: osgeolive11.0
+:Version: osgeolive13.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 @LOGO_mapserver@
@@ -28,25 +28,25 @@ such as `WMS <http://www.opengeospatial.org/standards/wms>`__, `WFS
     :depth: 1
 
 
-Configure MapServer using the MapFile configuration file
-================================================================================
+Configure MapServer using the Mapfile configuration file
+========================================================
 
 .. note:: 
 
   **What will I learn ?** In this section, you will learn what a 
-  MapFile is and how to configure it to allow MapServer to serve a shapefile 
+  Mapfile is and how to configure it to allow MapServer to serve a shapefile 
   as images using WMS requests.
 
-What is a MapFile ?
---------------------------------------------------------------------------------
+What is a Mapfile ?
+-------------------
 
 The `Mapfile <http://mapserver.org/mapfile/index.html>`_ is the 
 configuration file that MapServer uses to render geospatial data as images 
 or vector data. Its main purpose is to define the layers it can draw, how to 
 read necessary data, and how to render it (e.g. color, symbol, label, etc...).
 
-Creating my first MapFile
---------------------------------------------------------------------------------
+Creating my first Mapfile
+-------------------------
 
 #. Open any text editor (e.g. :menuselection:`Applications --> Accessories --> 
    Leafpad`).
@@ -70,9 +70,9 @@ Put the following content in it::
 
     WEB
       METADATA
-        ows_title "MapServer Quickstart"      
+        ows_title "MapServer Quickstart"
         ows_enable_request "*"
-        ows_srs "EPSG:4326 EPSG:25832 EPSG:25833"        
+        ows_srs "EPSG:4326 EPSG:25832 EPSG:25833"
       END
     END
 
@@ -96,13 +96,13 @@ Put the following content in it::
   The example uses the natural earth dataset, which is already on OSGeoLive at :file:`~/data/natural_earth2` (a short cut to 
   :file:`/usr/local/share/data/natural_earth2`).
 
-Each object in a MapFile starts with its name (for example **MAP**) and ends 
-with an **END**.  A MapFile always starts with the **MAP** object and should 
-contain a list of **LAYER** objects the MapFile can read and draw. In our 
-MapFile, we currently have only one layer defined.
+Each object in a Mapfile starts with its name (for example **MAP**) and ends 
+with an **END**.  A Mapfile always starts with the **MAP** object and should 
+contain a list of **LAYER** objects the Mapfile can read and draw. In our 
+Mapfile, we currently have only one layer defined.
 
 Let's take a look at some of the objects (and properties) defined in our 
-MapFile: 
+Mapfile: 
 
  * EXTENT: sets the default geospatial bounding box for this configuration.
  * LAYER: defines access and display properties for a spatial dataset.  We'll 
@@ -110,13 +110,13 @@ MapFile:
  * SHAPEPATH: sets a base path for file-based data (e.g. shapefiles or tiff 
    images). 
 
-If we look closer at the **LAYER** in our MapFile, we'll see that it 
+If we look closer at the **LAYER** in our Mapfile, we'll see that it 
 contains a bunch of properties and objects too. Among them are:
 
  * STATUS: defines whether the layer can be drawn (*ON*), can't be drawn 
    (*OFF*) or is always drawn (*DEFAULT*).
  * TYPE: the geometry type that MapServer should use when rendering the data 
-   as an image. In our MapFile, the data will be drawn as *polygons*.
+   as an image. In our Mapfile, the data will be drawn as *polygons*.
  * DATA: the name of the spatial data file this layer uses, in this case a 
    shapefile.
  * CLASS: determines how to draw a layer (styling). We'll cover this object in 
@@ -124,19 +124,19 @@ contains a bunch of properties and objects too. Among them are:
 
 .. note::
 
-  A complete list of the available objects and properties a MapFile can have 
+  A complete list of the available objects and properties a Mapfile can have 
   can be found in the `MapServer documentation page 
   <http://mapserver.org/mapfile/index.html>`_.
 
 
 
 Render a map image with MapServer using a WMS **GetMap** request
-================================================================================
+================================================================
 
 .. note::
 
   **What will I learn ?** You will learn how to use to render an image with 
-  layers from a MapFile with MapServer using an OGC WMS request.
+  layers from a Mapfile with MapServer using an OGC WMS request.
 
 Open a web browser and enter the following URL::
 
@@ -144,10 +144,10 @@ Open a web browser and enter the following URL::
 
 What does the above mean?  If we put it in simple words, it's a `Web Map 
 Service (WMS) <http://www.opengeospatial.org/standards/wms>`_ **GetMap** 
-request that tells MapServer to "*use the following MapFile to render the 
+request that tells MapServer to "*use the following Mapfile to render the 
 specified layers as a png image based on some user-supplied parameters such 
 as image size, geographical extent, projection, etc.*".  All layers 
-specified in the "*&LAYERS=...*" property having *STATUS ON* in the MapFile 
+specified in the "*&LAYERS=...*" property having *STATUS ON* in the Mapfile 
 will be rendered in addition to all layers with *STATUS DEFAULT*. The 
 result looks like the following:
 
@@ -178,16 +178,16 @@ file:///home/user/mymap.png.
 
 
 
-Add a new layer to the MapFile to serve a local shapefile
-================================================================================
+Add a new layer to the Mapfile to serve a local Shapefile
+=========================================================
 
 .. note::
 
   **What will I learn ?** You will learn how to add a new layer object 
-  definition to your MapFile.
+  definition to your Mapfile.
 
-We will now add a new layer to our MapFile. Before the last *END* statement 
-in the MapFile, add the following layer configuration::
+We will now add a new layer to our Mapfile. Before the last *END* statement 
+in the Mapfile, add the following layer configuration::
 
   LAYER
     NAME "Lakes"
@@ -201,7 +201,7 @@ in the MapFile, add the following layer configuration::
     END 
   END
 
-Now we have 2 layer definitions in our MapFile. Note that the new one we 
+Now we have 2 layer definitions in our Mapfile. Note that the new one we 
 just added has the "STATUS" property set to "ON". That means that unless we 
 specifically request it, it won't be rendered.
 
@@ -219,15 +219,15 @@ addition of the lakes from our new layer:
 
 
 
-Style a layer using MapFile configurations
-================================================================================
+Style a layer using Mapfile configurations
+==========================================
 
 .. note::
 
   **What will I learn ?** You will see an example of styling elements inside 
   a layer depending on some of its data properties.
 
-In a MapFile, a LAYER object can contain an infinite number of CLASS 
+In a Mapfile, a LAYER object can contain an infinite number of CLASS 
 objects. These are used to style the elements contained in the spatial data 
 file (DATA). For example, if we look closer at our "ne_10m_lakes" data file 
 using a tool such as `ogrinfo <http://www.gdal.org/ogrinfo.html>`_, we'll 
@@ -284,12 +284,12 @@ rendered with a black outline:
 
 
 Publish your data as OGC WMS (Web Map Service)
-================================================================================
+==============================================
 
 MapServer supports different OGC Standards like OGC WMS, WFS or WCS. With OGC WMS you can publish your data as a Map Service and integrate the service in a Desktop GIS like QGIS or in a Web Client like OpenLayers or Mapbender.
 
 Using QGIS Desktop to load your OGC WMS
---------------------------------------------------------------------------------
+---------------------------------------
 
 #. Start QGIS via :menuselection:`Geospatial --> Desktop GIS --> QGIS Desktop`. Go to :menuselection:`Layer --> Add Layer --> Add WMS/WMTS Layer`.
 
@@ -306,7 +306,7 @@ Then you can connect to your service and add one or more layers of the service t
 
 
 What Next?
-================================================================================
+==========
 
 This is a simple example, but you can do much, much more. The MapServer 
 project website contains many resources to help you get started. Here's a 
@@ -315,7 +315,7 @@ few resources to check out next:
 * Read the `Introduction to MapServer 
   <http://mapserver.org/introduction.html#introduction>`_.
 * Have a look at the `MapServer Tutorial 
-  <http://www.mapserver.org/tutorial/index.html>`_ which contains more MapFile 
+  <http://www.mapserver.org/tutorial/index.html>`_ which contains more Mapfile 
   examples.
 * Check the `OGC Support and Configuration 
   <http://www.mapserver.org/ogc/index.html>`_ to learn more about OGC 

--- a/doc/quickstart/mapserver_quickstart.rst
+++ b/doc/quickstart/mapserver_quickstart.rst
@@ -53,48 +53,48 @@ Creating my first Mapfile
 #. Create the file "mapserver_quickstart.map" in your home directory: 
    :file:`/home/user/mapserver_quickstart.map`
 
-Put the following content in it::
+   Put the following content in it::
+   
+     MAP
+       NAME "MAPSERVER_QUICKSTART"
+       EXTENT -137 29 -53 88
+       UNITS DD
+       SHAPEPATH "/home/user/data/natural_earth2/"
+       SIZE 800 600
+   
+       IMAGETYPE PNG24
+     
+       PROJECTION
+         "init=epsg:4326" 
+       END
+   
+       WEB
+         METADATA
+           ows_title "MapServer Quickstart"
+           ows_enable_request "*"
+           ows_srs "EPSG:4326 EPSG:25832 EPSG:25833"
+         END
+       END
+   
+       LAYER
+         NAME "Countries"
+         STATUS ON
+         TYPE POLYGON
+         DATA "ne_10m_admin_0_countries"
+         CLASS 
+           STYLE
+             COLOR 246 241 223
+             OUTLINECOLOR 0 0 0
+           END
+         END 
+       END
+   
+     END
 
-  MAP
-    NAME "MAPSERVER_QUICKSTART"
-    EXTENT -137 29 -53 88
-    UNITS DD
-    SHAPEPATH "/home/user/data/natural_earth2/"
-    SIZE 800 600
-
-    IMAGETYPE PNG24
-  
-    PROJECTION
-      "init=epsg:4326" 
-    END
-
-    WEB
-      METADATA
-        ows_title "MapServer Quickstart"
-        ows_enable_request "*"
-        ows_srs "EPSG:4326 EPSG:25832 EPSG:25833"
-      END
-    END
-
-    LAYER
-      NAME "Countries"
-      STATUS ON
-      TYPE POLYGON
-      DATA "ne_10m_admin_0_countries"
-      CLASS 
-        STYLE
-          COLOR 246 241 223
-          OUTLINECOLOR 0 0 0
-        END
-      END 
-    END
-
-  END
-
-.. note::
-
-  The example uses the natural earth dataset, which is already on OSGeoLive at :file:`~/data/natural_earth2` (a short cut to 
-  :file:`/usr/local/share/data/natural_earth2`).
+   .. note::
+   
+     The example uses the natural earth dataset, which is already on OSGeoLive at :file:`~/data/natural_earth2` (a short cut to 
+     :file:`/usr/local/share/data/natural_earth2`).
 
 Each object in a Mapfile starts with its name (for example **MAP**) and ends 
 with an **END**.  A Mapfile always starts with the **MAP** object and should 
@@ -297,12 +297,12 @@ Using QGIS Desktop to load your OGC WMS
 
 #. Save your settings:
 
-http://localhost/cgi-bin/mapserv?map=/home/user/mapserver_quickstart.map&SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0  
+   http://localhost/cgi-bin/mapserv?map=/home/user/mapserver_quickstart.map&SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0  
 
 Then you can connect to your service and add one or more layers of the service to your QGIS project. If you choose the layer with the ID 0 you can load the whole service with all layers at once.
 
-  .. image:: /images/projects/mapserver/mapserver_load_wms_to_qgis.png
-    :scale: 70 %
+.. image:: /images/projects/mapserver/mapserver_load_wms_to_qgis.png
+ :scale: 70 %
 
 
 What Next?


### PR DESCRIPTION
This pull request contains the following updates and relates to https://github.com/OSGeo/OSGeoLive-doc/pull/528:

- Change title underlines to match length
- Update the :Version: parameter
- Standardise the use of "Mapfile" - this should begin with a capital but lower case f as per https://www.mapserver.org/mapfile/
- Remove some redundant whitespace
- Capitalise Shapefile
- Some updates to indentation for numbering
